### PR TITLE
aggregate targets make targets explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next Version
 
+### Added
+
+- Added support for `enableGPUFrameCaptureMode` #1251 @bsudekum
+
 ## 2.32.0
 
 ### Added

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -804,6 +804,7 @@ The different actions share some properties:
 - [ ] **preActions**: **[[Execution Action](#execution-action)]** - Scripts that are run *before* the action
 - [ ] **postActions**: **[[Execution Action](#execution-action)]** - Scripts that are run *after* the action
 - [ ] **environmentVariables**: **[[Environment Variable](#environment-variable)]** or **[String:String]** - `run`, `test` and `profile` actions can define the environment variables. When passing a dictionary, every key-value entry maps to a corresponding variable that is enabled.
+- [ ] **enableGPUFrameCaptureMode**: **GPUFrameCaptureMode** - Property value set for `GPU Frame Capture`. Possible values are `autoEnabled`, `metal`, `openGL`, `disabled`. Default is `autoEnabled`.
 - [ ] **disableMainThreadChecker**: **Bool** - `run` and `test` actions can define a boolean that indicates that this scheme should disable the Main Thread Checker. This defaults to false
 - [ ] **stopOnEveryMainThreadCheckerIssue**: **Bool** - a boolean that indicates if this scheme should stop at every Main Thread Checker issue. This defaults to false
 - [ ] **language**: **String** - `run` and `test` actions can define a language that is used for Application Language

--- a/Sources/ProjectSpec/AggregateTarget.swift
+++ b/Sources/ProjectSpec/AggregateTarget.swift
@@ -3,7 +3,7 @@ import JSONUtilities
 
 public struct AggregateTarget: ProjectTarget {
     public var name: String
-    public var targets: [String]
+    public var targets: [TestableTargetReference]
     public var settings: Settings
     public var buildScripts: [BuildScript]
     public var configFiles: [String: String]
@@ -12,7 +12,7 @@ public struct AggregateTarget: ProjectTarget {
 
     public init(
         name: String,
-        targets: [String],
+        targets: [TestableTargetReference],
         settings: Settings = .empty,
         configFiles: [String: String] = [:],
         buildScripts: [BuildScript] = [],
@@ -32,7 +32,7 @@ public struct AggregateTarget: ProjectTarget {
 extension AggregateTarget: CustomStringConvertible {
 
     public var description: String {
-        "\(name)\(targets.isEmpty ? "" : ": \(targets.joined(separator: ", "))")"
+        "\(name)\(targets.isEmpty ? "" : ": \(targets.compactMap { $0.description }.joined(separator: ", "))")"
     }
 }
 
@@ -66,7 +66,7 @@ extension AggregateTarget: JSONEncodable {
     public func toJSONValue() -> Any {
         [
             "settings": settings.toJSONValue(),
-            "targets": targets,
+            "targets": targets.map { $0.toJSONValue() },
             "configFiles": configFiles,
             "attributes": attributes,
             "buildScripts": buildScripts.map { $0.toJSONValue() },

--- a/Sources/ProjectSpec/Project.swift
+++ b/Sources/ProjectSpec/Project.swift
@@ -92,7 +92,27 @@ public struct Project: BuildSettingsContainer {
     }
 
     public func getProjectTarget(_ targetName: String) -> ProjectTarget? {
-        targetsMap[targetName] ?? aggregateTargetsMap[targetName]
+//        if targetName.contains("/") {
+//            let targetTokens = targetName.components(separatedBy: "/")
+//            
+//            if 2 == targetTokens.count
+//                , let project = targetTokens.first
+//                , let targetName = targetTokens.last
+//                , let reference = self.projectReferencesMap[project] {
+//                
+//                print("Project: \(project)")
+//                
+//                let version = Version("1.0.0")
+//                do {
+//                    
+////                    let remoteProject = try SpecLoader(version: version).loadProject(path: Path(reference.path), projectRoot: nil, variables: [:])
+////                    return remoteProject.targetsMap[targetName]
+//                } catch {
+//                    print (error)
+//                }
+//            }
+//        }
+        return targetsMap[targetName] ?? aggregateTargetsMap[targetName]
     }
 
     public func getConfig(_ configName: String) -> Config? {

--- a/Sources/ProjectSpec/Project.swift
+++ b/Sources/ProjectSpec/Project.swift
@@ -92,27 +92,7 @@ public struct Project: BuildSettingsContainer {
     }
 
     public func getProjectTarget(_ targetName: String) -> ProjectTarget? {
-//        if targetName.contains("/") {
-//            let targetTokens = targetName.components(separatedBy: "/")
-//            
-//            if 2 == targetTokens.count
-//                , let project = targetTokens.first
-//                , let targetName = targetTokens.last
-//                , let reference = self.projectReferencesMap[project] {
-//                
-//                print("Project: \(project)")
-//                
-//                let version = Version("1.0.0")
-//                do {
-//                    
-////                    let remoteProject = try SpecLoader(version: version).loadProject(path: Path(reference.path), projectRoot: nil, variables: [:])
-////                    return remoteProject.targetsMap[targetName]
-//                } catch {
-//                    print (error)
-//                }
-//            }
-//        }
-        return targetsMap[targetName] ?? aggregateTargetsMap[targetName]
+        targetsMap[targetName] ?? aggregateTargetsMap[targetName]
     }
 
     public func getConfig(_ configName: String) -> Config? {

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -109,6 +109,7 @@ public struct Scheme: Equatable {
         public var preActions: [ExecutionAction]
         public var postActions: [ExecutionAction]
         public var environmentVariables: [XCScheme.EnvironmentVariable]
+        public var enableGPUFrameCaptureMode: XCScheme.LaunchAction.GPUFrameCaptureMode
         public var disableMainThreadChecker: Bool
         public var stopOnEveryMainThreadCheckerIssue: Bool
         public var language: String?
@@ -129,6 +130,7 @@ public struct Scheme: Equatable {
             preActions: [ExecutionAction] = [],
             postActions: [ExecutionAction] = [],
             environmentVariables: [XCScheme.EnvironmentVariable] = [],
+            enableGPUFrameCaptureMode: XCScheme.LaunchAction.GPUFrameCaptureMode = XCScheme.LaunchAction.defaultGPUFrameCaptureMode,
             disableMainThreadChecker: Bool = disableMainThreadCheckerDefault,
             stopOnEveryMainThreadCheckerIssue: Bool = stopOnEveryMainThreadCheckerIssueDefault,
             language: String? = nil,
@@ -147,6 +149,7 @@ public struct Scheme: Equatable {
             self.postActions = postActions
             self.environmentVariables = environmentVariables
             self.disableMainThreadChecker = disableMainThreadChecker
+            self.enableGPUFrameCaptureMode = enableGPUFrameCaptureMode
             self.stopOnEveryMainThreadCheckerIssue = stopOnEveryMainThreadCheckerIssue
             self.language = language
             self.region = region
@@ -408,6 +411,11 @@ extension Scheme.Run: JSONObjectConvertible {
         preActions = jsonDictionary.json(atKeyPath: "preActions") ?? []
         postActions = jsonDictionary.json(atKeyPath: "postActions") ?? []
         environmentVariables = try XCScheme.EnvironmentVariable.parseAll(jsonDictionary: jsonDictionary)
+        if let gpuFrameCaptureMode: String = jsonDictionary.json(atKeyPath: "enableGPUFrameCaptureMode") {
+            enableGPUFrameCaptureMode = XCScheme.LaunchAction.GPUFrameCaptureMode.fromJSONValue(gpuFrameCaptureMode)
+        } else {
+            enableGPUFrameCaptureMode = XCScheme.LaunchAction.defaultGPUFrameCaptureMode
+        }
         disableMainThreadChecker = jsonDictionary.json(atKeyPath: "disableMainThreadChecker") ?? Scheme.Run.disableMainThreadCheckerDefault
         stopOnEveryMainThreadCheckerIssue = jsonDictionary.json(atKeyPath: "stopOnEveryMainThreadCheckerIssue") ?? Scheme.Run.stopOnEveryMainThreadCheckerIssueDefault
         language = jsonDictionary.json(atKeyPath: "language")
@@ -448,6 +456,10 @@ extension Scheme.Run: JSONEncodable {
             "executable": executable,
             "macroExpansion": macroExpansion
         ]
+
+        if enableGPUFrameCaptureMode != XCScheme.LaunchAction.defaultGPUFrameCaptureMode {
+            dict["enableGPUFrameCaptureMode"] = enableGPUFrameCaptureMode.toJSONValue()
+        }
 
         if disableMainThreadChecker != Scheme.Run.disableMainThreadCheckerDefault {
             dict["disableMainThreadChecker"] = disableMainThreadChecker
@@ -862,5 +874,35 @@ extension XCScheme.EnvironmentVariable: JSONEncodable {
         }
 
         return dict
+    }
+}
+
+extension XCScheme.LaunchAction.GPUFrameCaptureMode: JSONEncodable {
+    public func toJSONValue() -> Any {
+        switch self {
+        case .autoEnabled:
+            return "autoEnabled"
+        case .metal:
+            return "metal"
+        case .openGL:
+            return "openGL"
+        case .disabled:
+            return "disabled"
+        }
+    }
+
+    static func fromJSONValue(_ string: String) -> XCScheme.LaunchAction.GPUFrameCaptureMode {
+        switch string {
+        case "autoEnabled":
+            return .autoEnabled
+        case "metal":
+            return .metal
+        case "openGL":
+            return .openGL
+        case "disabled":
+            return .disabled
+        default:
+            fatalError("Invalid enableGPUFrameCaptureMode value. Valid values are: autoEnabled, metal, openGL, disabled")
+        }
     }
 }

--- a/Sources/ProjectSpec/SpecValidation.swift
+++ b/Sources/ProjectSpec/SpecValidation.swift
@@ -147,9 +147,9 @@ extension Project {
 
         for target in aggregateTargets {
             for dependency in target.targets {
-                if getProjectTarget(dependency) == nil, let projectName = dependency.components(separatedBy: "/").first,
+                if getProjectTarget(dependency.name) == nil, let projectName = dependency.reference.components(separatedBy: "/").first,
                    (getPackage(projectName) == nil && getProjectReference(projectName) == nil) {
-                    errors.append(.invalidTargetDependency(target: target.name, dependency: dependency))
+                    errors.append(.invalidTargetDependency(target: target.name, dependency: dependency.reference))
                 }
             }
         }

--- a/Sources/ProjectSpec/TestTargeReference.swift
+++ b/Sources/ProjectSpec/TestTargeReference.swift
@@ -20,6 +20,31 @@ public struct TestableTargetReference: Hashable {
         case local
         case project(String)
         case package(String)
+        
+        
+        /// Check whether target is from the current project
+        /// - Returns: true if the current location is from the current `local` project, returns false if it's a `package` or `project`
+        public func isLocal() -> Bool {
+            return self == .local 
+        }
+        
+        /// Check whether target is referring to an external project
+        /// - Returns: true if the target is from another `package` or `project`, returns false if it's from the current `local` project
+        public func isExternal() -> Bool {
+            return self != .local
+        }
+        
+        
+        /// Returns project name, if the project is external
+        /// - Returns: If project is local, return an empty string. If project is external return name.
+        public func getProjectName() -> String {
+            switch self {
+            case .local:
+                return ""
+            case .project(let root), .package(let root):
+                return "\(root)"
+            }
+        }
     }
 
     public init(name: String, location: Location) {

--- a/Sources/XcodeGenKit/CarthageDependencyResolver.swift
+++ b/Sources/XcodeGenKit/CarthageDependencyResolver.swift
@@ -110,8 +110,8 @@ public class CarthageDependencyResolver {
                     }
                 }
             } else if let aggregateTarget = projectTarget as? AggregateTarget {
-                for dependencyName in aggregateTarget.targets {
-                    if let projectTarget = project.getProjectTarget(dependencyName) {
+                for dependency in aggregateTarget.targets {
+                    if let projectTarget = project.getProjectTarget(dependency.name) {
                         queue.append(projectTarget)
                     }
                 }

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -338,33 +338,23 @@ public class PBXProjGenerator {
         }
 
         let dependencies: [PBXTargetDependency] = target.targets.map {
-            let dependency = $0
-<<<<<<< Updated upstream
-            if dependency.contains("/") && dependency.components(separatedBy: "/").count == 2 {
-                let tokens: [String] = dependency.components(separatedBy: "/")
-                let projectName: String = tokens[0]
-                let targetName: String = tokens[1]
-=======
-            if dependency.contains("/")
-                , let tokens: [String] = dependency.components(separatedBy: " :/")
-                , tokens.count >= 2
-                , let type: String = (tokens.count == 3) ? tokens[0].trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) : "target: "
-                , let projectName: String = tokens[tokens.count-2].trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
-                , let targetName: String = tokens[tokens.count-1].trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) {
->>>>>>> Stashed changes
-                
-                switch type {
-                case "package:":
-                    let productName = targetName
-                    let packageDependency = addObject(
-                        XCSwiftPackageProductDependency(productName: productName)
+            let dependency: TestableTargetReference = $0
+            
+            if dependency.location.isExternal() {
+                let projectName: String = dependency.location.getProjectName()
+                let targetName: String = dependency.name
+
+                switch dependency.location {
+                case .package(let packageName):
+                    let packageDependency = self.addObject(
+                        XCSwiftPackageProductDependency(productName: packageName)
                     )
-                    
-                    let targetDependency = addObject(
+
+                    let targetDependency = self.addObject(
                         PBXTargetDependency( product: packageDependency)
                     )
                     return targetDependency
-                
+
                 default:
                     do {
                         return try generateExternalTargetDependency(from: target.name, to: targetName, in: projectName, platform: .iOS).0
@@ -373,7 +363,7 @@ public class PBXProjGenerator {
                     }
                 }
             }
-            return generateTargetDependency(from: target.name, to: $0, platform: nil)
+            return generateTargetDependency(from: target.name, to: dependency.name, platform: nil)
         }
 
         let defaultConfigurationName = project.options.defaultConfig ?? project.configs.first?.name ?? ""

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -163,6 +163,7 @@ public class PBXProjGenerator {
         }
 
         for (name, package) in project.packages {
+            print(name)
             switch package {
             case let .remote(url, versionRequirement):
                 let packageReference = XCRemoteSwiftPackageReference(repositoryURL: url, versionRequirement: versionRequirement)
@@ -338,12 +339,22 @@ public class PBXProjGenerator {
 
         let dependencies: [PBXTargetDependency] = target.targets.map {
             let dependency = $0
+<<<<<<< Updated upstream
             if dependency.contains("/") && dependency.components(separatedBy: "/").count == 2 {
                 let tokens: [String] = dependency.components(separatedBy: "/")
                 let projectName: String = tokens[0]
                 let targetName: String = tokens[1]
+=======
+            if dependency.contains("/")
+                , let tokens: [String] = dependency.components(separatedBy: " :/")
+                , tokens.count >= 2
+                , let type: String = (tokens.count == 3) ? tokens[0].trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) : "target: "
+                , let projectName: String = tokens[tokens.count-2].trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+                , let targetName: String = tokens[tokens.count-1].trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) {
+>>>>>>> Stashed changes
                 
-                if nil != project.packages[projectName] {
+                switch type {
+                case "package:":
                     let productName = targetName
                     let packageDependency = addObject(
                         XCSwiftPackageProductDependency(productName: productName)
@@ -353,12 +364,13 @@ public class PBXProjGenerator {
                         PBXTargetDependency( product: packageDependency)
                     )
                     return targetDependency
-                }
                 
-                do {
-                    return try generateExternalTargetDependency(from: target.name, to: targetName, in: projectName, platform: .iOS).0
-                } catch {
-                    print("Error: \(error)")
+                default:
+                    do {
+                        return try generateExternalTargetDependency(from: target.name, to: targetName, in: projectName, platform: .iOS).0
+                    } catch {
+                        print("Error: \(error)")
+                    }
                 }
             }
             return generateTargetDependency(from: target.name, to: $0, platform: nil)

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -163,7 +163,6 @@ public class PBXProjGenerator {
         }
 
         for (name, package) in project.packages {
-            print(name)
             switch package {
             case let .remote(url, versionRequirement):
                 let packageReference = XCRemoteSwiftPackageReference(repositoryURL: url, versionRequirement: versionRequirement)

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -308,6 +308,7 @@ public class SchemeGenerator {
             askForAppToLaunch: scheme.run?.askForAppToLaunch,
             allowLocationSimulation: allowLocationSimulation,
             locationScenarioReference: locationScenarioReference,
+            enableGPUFrameCaptureMode: scheme.run?.enableGPUFrameCaptureMode ?? XCScheme.LaunchAction.defaultGPUFrameCaptureMode,
             disableMainThreadChecker: scheme.run?.disableMainThreadChecker ?? Scheme.Run.disableMainThreadCheckerDefault,
             stopOnEveryMainThreadCheckerIssue: scheme.run?.stopOnEveryMainThreadCheckerIssue ?? Scheme.Run.stopOnEveryMainThreadCheckerIssueDefault,
             commandlineArguments: launchCommandLineArgs,

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_Scheme.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_Scheme.xcscheme
@@ -87,6 +87,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUFrameCaptureMode = "3"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/Tests/Fixtures/TestProject/project.yml
+++ b/Tests/Fixtures/TestProject/project.yml
@@ -428,6 +428,7 @@ schemes:
         allow: true
         defaultLocation: Honolulu, HI, USA
       customLLDBInit: ${SRCROOT}/.lldbinit
+      enableGPUFrameCaptureMode: "disabled"
       storeKitConfiguration: "App_iOS/Configuration.storekit"
       macroExpansion: App_iOS 
     test:

--- a/Tests/Fixtures/legacy_paths_test/legacy_included_paths_test.yml
+++ b/Tests/Fixtures/legacy_paths_test/legacy_included_paths_test.yml
@@ -26,7 +26,7 @@ targets:
 aggregateTargets:
   IncludedAggregateTarget:
     targets:
-      - IncludedTarget
+      - local: IncludedTarget
     configFiles:
       Config: config
     buildScripts:

--- a/Tests/Fixtures/paths_test.yml
+++ b/Tests/Fixtures/paths_test.yml
@@ -26,7 +26,7 @@ targets:
 aggregateTargets:
   NewAggregateTarget:
     targets:
-      - NewTarget
+      - local: NewTarget
     configFiles:
       Config: config
     buildScripts:

--- a/Tests/Fixtures/paths_test/included_paths_test.yml
+++ b/Tests/Fixtures/paths_test/included_paths_test.yml
@@ -3,6 +3,8 @@ configFiles:
   IncludedConfig: config
 projectReferences:
   ProjX: { path: ../TestProject/Project.xcodeproj }
+packages:
+  SPM-project: { path: ../SPM-project }
 targets:
   IncludedTarget:
     type: application
@@ -31,9 +33,9 @@ targets:
 aggregateTargets:
   IncludedAggregateTarget:
     targets:
-      - IncludedTarget
+      - local: IncludedTarget
       - project: AnotherProject/ExternalTarget
-      - package: ../SPM-project/spm-project
+      - package: SPM-project/spm-project
     configFiles:
       Config: config
     buildScripts:

--- a/Tests/Fixtures/paths_test/included_paths_test.yml
+++ b/Tests/Fixtures/paths_test/included_paths_test.yml
@@ -32,7 +32,8 @@ aggregateTargets:
   IncludedAggregateTarget:
     targets:
       - IncludedTarget
-      - AnotherProject/ExternalTarget
+      - project: AnotherProject/ExternalTarget
+      - package: ../SPM-project/spm-project
     configFiles:
       Config: config
     buildScripts:

--- a/Tests/Fixtures/paths_test/recursive_test/recursive_test.yml
+++ b/Tests/Fixtures/paths_test/recursive_test/recursive_test.yml
@@ -26,7 +26,7 @@ targets:
 aggregateTargets:
   RecursiveAggregateTarget:
     targets:
-      - RecursiveTarget
+      - local: RecursiveTarget
     configFiles:
       Config: config
     buildScripts:

--- a/Tests/ProjectSpecTests/ProjectSpecTests.swift
+++ b/Tests/ProjectSpecTests/ProjectSpecTests.swift
@@ -640,6 +640,7 @@ class ProjectSpecTests: XCTestCase {
                                                                     environmentVariables: [XCScheme.EnvironmentVariable(variable: "foo",
                                                                                                                         value: "bar",
                                                                                                                         enabled: false)],
+                                                                    enableGPUFrameCaptureMode: .openGL,
                                                                     launchAutomaticallySubstyle: "2",
                                                                     storeKitConfiguration: "Configuration.storekit"),
                                                     test: Scheme.Test(config: "Config",

--- a/Tests/ProjectSpecTests/ProjectSpecTests.swift
+++ b/Tests/ProjectSpecTests/ProjectSpecTests.swift
@@ -574,7 +574,7 @@ class ProjectSpecTests: XCTestCase {
                                                                          workingDirectory: "foo"),
                                                     attributes: ["foo": "bar"])],
                                    aggregateTargets: [AggregateTarget(name: "aggregate target",
-                                                                      targets: ["App"],
+                                                                      targets: [TestableTargetReference(name: "App", location: .local)],
                                                                       settings: Settings(buildSettings: ["buildSettings": "bar"],
                                                                                          configSettings: ["configSettings": Settings(buildSettings: [:],
                                                                                                                                      configSettings: [:],

--- a/Tests/ProjectSpecTests/SpecLoadingTests.swift
+++ b/Tests/ProjectSpecTests/SpecLoadingTests.swift
@@ -823,6 +823,7 @@ class SpecLoadingTests: XCTestCase {
                     "run": [
                         "config": "debug",
                         "launchAutomaticallySubstyle": 2,
+                        "enableGPUFrameCaptureMode": "disabled",
                         "storeKitConfiguration": "Configuration.storekit",
                     ],
                     "test": [
@@ -873,6 +874,7 @@ class SpecLoadingTests: XCTestCase {
 
                 let expectedRun = Scheme.Run(
                     config: "debug",
+                    enableGPUFrameCaptureMode: .disabled,
                     launchAutomaticallySubstyle: "2",
                     storeKitConfiguration: "Configuration.storekit"
                 )

--- a/Tests/ProjectSpecTests/SpecLoadingTests.swift
+++ b/Tests/ProjectSpecTests/SpecLoadingTests.swift
@@ -97,19 +97,19 @@ class SpecLoadingTests: XCTestCase {
                 try expect(project.aggregateTargets) == [
                     AggregateTarget(
                         name: "IncludedAggregateTarget",
-                        targets: ["IncludedTarget", "AnotherProject/ExternalTarget"],
+                        targets: [TestableTargetReference(name: "IncludedTarget", location: .local), TestableTargetReference(name: "ExternalTarget", location: .project("AnotherProject")), TestableTargetReference(name: "spm-project", location: .package("SPM-project"))],
                         configFiles: ["Config": "paths_test/config"],
                         buildScripts: [BuildScript(script: .path("paths_test/buildScript"))]
                     ),
                     AggregateTarget(
                         name: "NewAggregateTarget",
-                        targets: ["NewTarget"],
+                        targets: [TestableTargetReference(name: "NewTarget", location: .local)],
                         configFiles: ["Config": "config"],
                         buildScripts: [BuildScript(script: .path("buildScript"))]
                     ),
                     AggregateTarget(
                         name: "RecursiveAggregateTarget",
-                        targets: ["RecursiveTarget"],
+                        targets: [TestableTargetReference(name: "RecursiveTarget", location: .local)],
                         configFiles: ["Config": "paths_test/recursive_test/config"],
                         buildScripts: [BuildScript(script: .path("paths_test/recursive_test/buildScript"))]
                     ),
@@ -734,13 +734,13 @@ class SpecLoadingTests: XCTestCase {
 
             $0.it("parses aggregate targets") {
                 let dictionary: [String: Any] = [
-                    "targets": ["target_1", "target_2"],
+                    "targets": [["local": "target_1"], ["local": "target_2"]],
                     "settings": ["SETTING": "VALUE"],
                     "configFiles": ["debug": "file.xcconfig"],
                 ]
 
                 let project = try getProjectSpec(["aggregateTargets": ["AggregateTarget": dictionary]])
-                let expectedTarget = AggregateTarget(name: "AggregateTarget", targets: ["target_1", "target_2"], settings: ["SETTING": "VALUE"], configFiles: ["debug": "file.xcconfig"])
+                let expectedTarget = AggregateTarget(name: "AggregateTarget", targets: [TestableTargetReference(name: "target_1", location: .local), TestableTargetReference(name: "target_2", location: .local)], settings: ["SETTING": "VALUE"], configFiles: ["debug": "file.xcconfig"])
                 try expect(project.aggregateTargets) == [expectedTarget]
             }
 

--- a/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
@@ -52,7 +52,7 @@ class SchemeGeneratorTests: XCTestCase {
                 let scheme = try Scheme(
                     name: "MyScheme",
                     build: Scheme.Build(targets: [buildTarget], preActions: [preAction]),
-                    run: Scheme.Run(config: "Debug", askForAppToLaunch: true, launchAutomaticallySubstyle: "2", simulateLocation: simulateLocation, storeKitConfiguration: storeKitConfiguration, customLLDBInit: "/sample/.lldbinit"),
+                    run: Scheme.Run(config: "Debug", enableGPUFrameCaptureMode: .metal, askForAppToLaunch: true, launchAutomaticallySubstyle: "2", simulateLocation: simulateLocation, storeKitConfiguration: storeKitConfiguration, customLLDBInit: "/sample/.lldbinit"),
                     test: Scheme.Test(config: "Debug", targets: [
                         Scheme.Test.TestTarget(targetReference: TestableTargetReference(framework.name), location: "test.gpx"),
                         Scheme.Test.TestTarget(targetReference: TestableTargetReference(framework.name), location: "New York, NY, USA")
@@ -110,6 +110,7 @@ class SchemeGeneratorTests: XCTestCase {
                 try expect(xcscheme.launchAction?.locationScenarioReference?.referenceType) == Scheme.SimulateLocation.ReferenceType.predefined.rawValue
                 try expect(xcscheme.launchAction?.locationScenarioReference?.identifier) == "New York, NY, USA"
                 try expect(xcscheme.launchAction?.customLLDBInitFile) == "/sample/.lldbinit"
+                try expect(xcscheme.launchAction?.enableGPUFrameCaptureMode) == .metal
                 try expect(xcscheme.testAction?.customLLDBInitFile) == "/test/.lldbinit"
                 try expect(xcscheme.testAction?.systemAttachmentLifetime).to.beNil()
                 
@@ -266,7 +267,7 @@ class SchemeGeneratorTests: XCTestCase {
                 let scheme = Scheme(
                     name: "TestScheme",
                     build: Scheme.Build(targets: [buildTarget]),
-                    run: Scheme.Run(config: "Debug", debugEnabled: false, simulateLocation: .init(allow: true, defaultLocation: "File.gpx"), storeKitConfiguration: "Configuration.storekit")
+                    run: Scheme.Run(config: "Debug", enableGPUFrameCaptureMode: .metal, debugEnabled: false, simulateLocation: .init(allow: true, defaultLocation: "File.gpx"), storeKitConfiguration: "Configuration.storekit")
                 )
                 let project = Project(
                     name: "test",
@@ -282,6 +283,7 @@ class SchemeGeneratorTests: XCTestCase {
                 try expect(xcscheme.launchAction?.storeKitConfigurationFileReference?.identifier) == "../../Configuration.storekit"
                 try expect(xcscheme.launchAction?.locationScenarioReference?.referenceType) == Scheme.SimulateLocation.ReferenceType.gpx.rawValue
                 try expect(xcscheme.launchAction?.locationScenarioReference?.identifier) == "../../File.gpx"
+                try expect(xcscheme.launchAction?.enableGPUFrameCaptureMode) == .metal
             }
 
             $0.it("generate scheme without debugger - test") {


### PR DESCRIPTION
Add support for `local:`, `package:` and `project:` to allow specific declaration where the target should be coming from.

This is using the `TestableTargetReference` which covers the implementation for this already. It would probably be cleaner to fold this into `TargetReference` or create another TargetReference type to be less confusing.